### PR TITLE
Pi and i constants

### DIFF
--- a/inginious_problems_math/__init__.py
+++ b/inginious_problems_math/__init__.py
@@ -111,8 +111,8 @@ class MathProblem(Problem):
         latex_str = re.sub("(\\\log_)(\w)(\(|\^)", "\\\log_{\\2}\\3", latex_str)
         latex_str = re.sub("(\\\log_)(\w)(\w+)", "\\\log_{\\2}(\\3)", latex_str)
         latex_str = re.sub(r'(\w)_(\w)(\w+)', r'\1_{\2}\3', latex_str) #x_ab means x_{a}b but x_{ab} correclty means x_{ab}
-        latex_str = re.sub(r'pi', r'\\pi', latex_str) #translates "pi" into the pi symbol (otherwise it's translated into p*i)
-        eq = parse_latex(latex_str).subs([("e", "E"), ("pi", pi)]) #add general constants
+        #general constants: always use i for imaginary constant, e for natural logarithm basis and \pi (or the symbol from toolbox) for pi
+        eq = parse_latex(latex_str).subs([("e", E), ("i", I)]) 
         return eq
 
 

--- a/inginious_problems_math/__init__.py
+++ b/inginious_problems_math/__init__.py
@@ -11,7 +11,7 @@ from flask import send_from_directory
 from sympy.core import Number
 from sympy.parsing.latex import parse_latex
 from sympy.printing.latex import latex
-from sympy import simplify, sympify, N, E, pi, Equality
+from sympy import simplify, sympify, N, E, pi, I, Equality
 
 from inginious.common.tasks_problems import Problem
 from inginious.frontend.task_problems import DisplayableProblem


### PR DESCRIPTION
Now, to use 'pi' the student/teacher must use the pi symbol from toolbox or '\pi'.
This removes the confusion between using 'pi' or '\pi'.

Now to use 'i' the imaginary constant, the student/teacher must use the i letter.
This adds the missing 'i' constant and also removes the confusion between 'i' and 'I'.