### PR TITLE
Quick fix

### DIFF
--- a/inginious_problems_math/math_problem.py
+++ b/inginious_problems_math/math_problem.py
@@ -128,8 +128,8 @@ class MathProblem(Problem):
         latex_str = re.sub("(\\\log_)(\w)(\w+)", "\\\log_{\\2}(\\3)", latex_str)
         latex_str = re.sub(r'(\w)_(\w)(\w+)', r'\1_{\2}\3', latex_str) #x_ab means x_{a}b but x_{ab} correclty means x_{ab}
         #general constants: always use i for imaginary constant, e for natural logarithm basis and \pi (or the symbol from toolbox) for pi
-        eq = parse_latex(latex_str).subs([("e", E), ("i", I), ("pi", pi)])
-        return sympify(eq)
+        eq = sympify(parse_latex(latex_str).subs([("e", E), ("i", I), ("pi", pi)]))
+        return simplify(eq)
 
     def is_equal(self, eq1, eq2):
         """Compare answers"""


### PR DESCRIPTION
This modification corrects an important error:
Some cases of expressions mathematically equal using different formats (such as x+x instead of 2x) were not considered as equal.
This also fix the same issue about matrix and intervals which had the same issue.

This is an extremely small but important fix.
It allows every input (being from the teacher or the student) to be simplified before being treated (being for simple math but also for interval or matrix)