### PR TITLE
fix for absolute value

### DIFF
--- a/inginious_problems_math/math_problem.py
+++ b/inginious_problems_math/math_problem.py
@@ -98,6 +98,7 @@ class MathProblem(Problem):
 
     @classmethod
     def parse_answer(cls, latex_str):
+
         # The \left and \right prefix are not supported by sympy (and useless for treatment)
         latex_str = re.sub("(\\\left|\\\right)", "", latex_str)
         latex_str = re.sub("(\\\log_)(\w)(\(|\^)", "\\\log_{\\2}\\3", latex_str)
@@ -105,6 +106,8 @@ class MathProblem(Problem):
         latex_str = re.sub(r'(\w)_(\w)(\w+)', r'\1_{\2}\3', latex_str) #x_ab means x_{a}b but x_{ab} correclty means x_{ab}
         latex_str = latex_str.replace("\\ne", "\\neq")
         latex_str = latex_str.replace("\\right|", "|")
+        latex_str = latex_str.replace("\\left|", "|")
+
         #general constants: always use i for imaginary constant, e for natural logarithm basis and \pi (or the symbol from toolbox) for pi
         eq = sympify(parse_latex(latex_str).subs([("e", E), ("i", I), ("pi", pi)]))
         return simplify(eq)

--- a/inginious_problems_math/math_problem.py
+++ b/inginious_problems_math/math_problem.py
@@ -104,6 +104,7 @@ class MathProblem(Problem):
         latex_str = re.sub("(\\\log_)(\w)(\w+)", "\\\log_{\\2}(\\3)", latex_str)
         latex_str = re.sub(r'(\w)_(\w)(\w+)', r'\1_{\2}\3', latex_str) #x_ab means x_{a}b but x_{ab} correclty means x_{ab}
         latex_str = latex_str.replace("\\ne", "\\neq")
+        latex_str = latex_str.replace("\\right|", "|")
         #general constants: always use i for imaginary constant, e for natural logarithm basis and \pi (or the symbol from toolbox) for pi
         eq = sympify(parse_latex(latex_str).subs([("e", E), ("i", I), ("pi", pi)]))
         return simplify(eq)

--- a/inginious_problems_math/tests.py
+++ b/inginious_problems_math/tests.py
@@ -34,6 +34,9 @@ class TestParseAnswer(unittest.TestCase):
         self.assertEqual((int(MathProblem.parse_answer("x3+2-x-1").subs("x",17))),35)
         self.assertEqual((int(MathProblem.parse_answer("\\frac{3xxx+2xx-xxx-1xx}{xx}").subs("x",17))),35)
         self.assertEqual((int(MathProblem.parse_answer("\\frac{15xxx+10xx-5xxx-5xx}{5xx}").subs("x",17))),35)
+        self.assertEqual((int(MathProblem.parse_answer("|x|").subs("x",-5))),5)
+        self.assertEqual((int(MathProblem.parse_answer("\\left|x\\right|").subs("x",-5))),5)
+
 
 
     def test_simple_polynomial(self):


### PR DESCRIPTION
Seems like some specific symbols use 3 \, some use 2\ no idea why...
But this should fix the issue with the usage of "absolute value" ||