### PR TITLE
Error_message visibility options

### DIFF
--- a/inginious_problems_math/math_problem.py
+++ b/inginious_problems_math/math_problem.py
@@ -33,6 +33,9 @@ class MathProblem(Problem):
         self._use_log = content.get("use_log", False)
         self._use_trigo = content.get("use_trigo", False)
         self._use_complex = content.get("use_complex", False)
+        self._error_message_visibility = content.get("error_msg_visibility", "always")
+        self._error_msg_hidden_until = content.get("error_msg_visibility_start", "2000-01-01 00:00:00")
+        self._error_msg_attempts = content.get("error_msg_attempts", 0)
 
     @classmethod
     def get_type(cls):
@@ -86,7 +89,10 @@ class MathProblem(Problem):
         for i in range(0, len(correct_answers)):
             try:
                 if not self.is_equal(student_answers[i], correct_answers[i]):
-                    msg = [self.gettext(language, self._error_message) or "_wrong_answer"]
+                    if self.check_visibility_error_msg(task_input):
+                        msg = [self.gettext(language, self._error_message) or "_wrong_answer"]
+                    else:
+                        msg = ["_wrong_answer"]
                     msg += ["Not correct : :math:`{}`".format(latex(student_answers[i]))]
                     return False, None, msg, 0, state
             except Exception as e:
@@ -101,6 +107,17 @@ class MathProblem(Problem):
         correct_len = len(correct_answer) == len(student_anwer)
         message = "Expected {} answer(s)".format(len(correct_answer))
         return [correct_len, message]
+
+    def check_visibility_error_msg(self, task_input):
+        """ Return a boolean enabling the error message to appear regarding of the options and the context"""
+        if self._error_message_visibility == 'hidden_until':
+            submission_date = task_input.get("@time", "2000-01-01 00:00:00")
+            return submission_date >= self._error_msg_hidden_until
+        if self._error_message_visibility == "after_attempt":
+            nbr_attempts = int(task_input.get("@attempts", "0"))
+            return nbr_attempts >= int(self._error_msg_attempts)
+        return True
+
 
     def sort(self, answers):
         """Sort the answers based on alphabetical order"""
@@ -166,6 +183,12 @@ class MathProblem(Problem):
     def parse_problem(cls, problem_content):
         problem_content = Problem.parse_problem(problem_content)
 
+        if "error_msg_visibility_start" in problem_content and problem_content["error_msg_visibility_start"] == '':
+            del problem_content["error_msg_visibility_start"]
+
+        if "error_msg_attempts" in problem_content and problem_content["error_msg_attempts"] == '':
+            del problem_content["error_msg_attempts"]
+            
         if "tolerance" in problem_content:
             if problem_content["tolerance"]:
                 problem_content["tolerance"] = float(problem_content["tolerance"])

--- a/inginious_problems_math/math_problem.py
+++ b/inginious_problems_math/math_problem.py
@@ -37,7 +37,6 @@ class MathProblem(Problem):
         self._error_message_visibility = content.get("error_msg_visibility", "always")
         self._error_msg_attempts = content.get("error_msg_attempts", 0)
         self._error_msg_visibility_start = content.get("error_msg_visibility_start", "2000-01-01 00:00:00")
-        print(self._error_msg_visibility_start)
 
     @classmethod
     def get_type(cls):

--- a/inginious_problems_math/math_problem.py
+++ b/inginious_problems_math/math_problem.py
@@ -37,6 +37,7 @@ class MathProblem(Problem):
         self._error_message_visibility = content.get("error_msg_visibility", "always")
         self._error_msg_attempts = content.get("error_msg_attempts", 0)
         self._error_msg_visibility_start = content.get("error_msg_visibility_start", "2000-01-01 00:00:00")
+        print(self._error_msg_visibility_start)
 
     @classmethod
     def get_type(cls):
@@ -188,17 +189,17 @@ class MathProblem(Problem):
     def parse_problem(cls, problem_content):
         problem_content = Problem.parse_problem(problem_content)
 
-        if "error_msg_visibility_start" in problem_content:
+        if "error_msg_visibility_start" in problem_content and problem_content["error_msg_visibility"] == "hidden_until":
             if problem_content["error_msg_visibility_start"] == '':
-                del problem_content["error_msg_visibility_start"]
+                problem_content["error_msg_visibility_start"] = '2000-01-01 00:00:00'
             else:
                 try:
                     datetime.strptime(problem_content["error_msg_visibility_start"], '%Y-%m-%d %X')
                 except ValueError:
                     raise ValueError("Invalid date format")
 
-        if "error_msg_attempts" in problem_content and problem_content["error_msg_attempts"] == '':
-            del problem_content["error_msg_attempts"]
+        if "error_msg_attempts" in problem_content and problem_content["error_msg_visibility"] == "after_attempt" and problem_content["error_msg_attempts"] == '':
+            problem_content["error_msg_attempts"] = 0
             
         if "tolerance" in problem_content:
             if problem_content["tolerance"]:

--- a/inginious_problems_math/math_problem.py
+++ b/inginious_problems_math/math_problem.py
@@ -117,8 +117,7 @@ class MathProblem(Problem):
                 submission_date = datetime.strptime(submission_date, '%Y-%m-%d %X')
                 return submission_date >= datetime.strptime(self._error_msg_visibility_start, '%Y-%m-%d %X')
             except ValueError:
-                #Default behavior is to show the error message if the date format isn't correct
-                return True
+                raise ValueError("Invalid date format")
         if self._error_message_visibility == "after_attempt":
             nbr_attempts = int(task_input.get("@attempts", "0"))
             return nbr_attempts >= int(self._error_msg_attempts)
@@ -196,9 +195,7 @@ class MathProblem(Problem):
                 try:
                     datetime.strptime(problem_content["error_msg_visibility_start"], '%Y-%m-%d %X')
                 except ValueError:
-                    print("ValE")
-                    #Default behavior is to always show the error message if the format of the date isn't correct
-                    problem_content["error_msg_visibility_start"] = "2000-01-01 00:00:00"
+                    raise ValueError("Invalid date format")
 
         if "error_msg_attempts" in problem_content and problem_content["error_msg_attempts"] == '':
             del problem_content["error_msg_attempts"]

--- a/inginious_problems_math/static/math.js
+++ b/inginious_problems_math/static/math.js
@@ -24,6 +24,11 @@ function studio_init_template_math(well, pid, problem)
     var comparison_type = 'symbolic';
     if("comparison_type" in problem)
         comparison_type = problem["comparison_type"];
+    var error_msg_visibility = 'always';
+    var error_msg_visibility_start = problem["error_msg_visibility_start"];
+    var error_msg_attempts = problem["error_msg_attempts"];
+    if("error_msg_visibility" in problem)
+        error_msg_visibility = problem["error_msg_visibility"];
     if("tolerance" in problem)
         tolerance = problem["tolerance"];
     if("success_message" in problem)
@@ -34,11 +39,16 @@ function studio_init_template_math(well, pid, problem)
         hints = problem["hints"];
     if("answer" in problem) // retrocompat
         problem["answers"] = [problem["answer"]];
+        
     $("#tolerance-" + pid).val(tolerance);
     $("#" + comparison_type + "-" + pid).prop("checked", true);
     $("#use_log-" + pid).prop("checked", use_log);
     $("#use_trigo-" + pid).prop("checked", use_trigo);
     $("#use_complex-" + pid).prop("checked", use_complex);
+    $("#error_msg_visibility-" + error_msg_visibility + "-" +  pid).prop("checked", true);
+    $("#error_msg_attempts-" + pid).prop("value", error_msg_attempts);
+    $("#error_msg_date_picker-" + pid).prop("value", error_msg_visibility_start);
+
     registerCodeEditor($('#success_message-' + pid)[0], 'rst', 1).setValue(success_message);
     registerCodeEditor($('#error_message-' + pid)[0], 'rst', 1).setValue(error_message);
     registerCodeEditor($('#hints-' + pid)[0], 'rst', 1).setValue(hints);

--- a/inginious_problems_math/templates/math_edit.html
+++ b/inginious_problems_math/templates/math_edit.html
@@ -98,6 +98,44 @@
                     </label></div>
                 </div>
             </div>
+            <div class="form-group row">
+                <label class="col-sm-2 control-label">{{_("Error message")}}</label>
+                <div class="col-sm-10">
+                    <label>
+                        <input type="radio" value="always" id="error_msg_visibility-always-PID" name="problem[PID][error_msg_visibility]"/>
+                        {{ _("Always visible") }}
+                    </label><br/>
+                    <div class="row">
+                        <div class="col-xs-12 col-lg-3">
+                            <label>
+                                <input type="radio" value="after_attempt" id="error_msg_visibility-after_attempt-PID" name="problem[PID][error_msg_visibility]"/>
+                                {{ _("Visible after : {nbr_attempts} attempts").format(nbr_attempts='</label></div><div class="col-xs-offset-1 col-lg-offset-0 col-xs-11 col-lg-2"><input id="error_msg_attempts-PID" name="problem[PID][error_msg_attempts]" class="form-control input-xs" style="height:20px;padding: 0 10px;" placeholder="5" type="number"></div><div class="col-xs-offset-1 col-lg-offset-0 col-xs-11 col-lg-3"><label>') | safe }}
+                            </label>
+                        </div>
+                    </div>
+                    <div class="row">
+                        <div class="col-xs-12 col-lg-3">
+                            <label class="control-label">
+                                <input type="radio" value="hidden_until" id="error_msg_visibility-hidden_until-PID" name="problem[PID][error_msg_visibility]"/>
+                                {{ _("Hidden until : ") }}
+                            </label>
+                        </div>
+                        <div class="col-xs-offset-1 col-lg-offset-0 col-xs-11 col-lg-4">
+                            <div class='input-group date' id='error_msg_visibility_start-PID' data-target-input="nearest" >
+                                    <input name="problem[PID][error_msg_visibility_start]" id="error_msg_date_picker-PID" data-target="#error_msg_visibility_start-PID" data-date-format="YYYY-MM-DD HH:mm:ss" placeholder="2021-06-29 10:00" type='text' class="form-control datetimepicker-input" />
+                                    <div class="input-group-append" data-target="#error_msg_visibility_start-PID" data-toggle="datetimepicker" >
+                                            <div class="input-group-text"><i class="fa fa-calendar" ></i></div>
+                                    </div>
+                            </div>
+                        </div>
+                        <script type="text/javascript">
+                            $(function() {
+                                $('#error_msg_visibility_start-PID').datetimepicker({locale: '{{user_manager.session_language()}}', sideBySide: true, format:'YYYY-MM-DD HH:mm:ss'});
+                            });
+                        </script>
+                    </div>
+                </div>
+            </div>
         </div>
     </div>
 {% endif %}


### PR DESCRIPTION
Every math subproblem have now an option to modify when the error message has to be display to students.
3 possibilities :
       - always visible
       - visible after a certain number of attempts (ex : >= 3 attempts)
       - visible only after a certain date/hour